### PR TITLE
feat: Specify Domain in Cookie Writing

### DIFF
--- a/mock_cookies_test.go
+++ b/mock_cookies_test.go
@@ -22,6 +22,7 @@ import (
 type MockcookieManager struct {
 	ctrl     *gomock.Controller
 	recorder *MockcookieManagerMockRecorder
+	isgomock struct{}
 }
 
 // MockcookieManagerMockRecorder is the mock recorder for MockcookieManager.
@@ -70,6 +71,21 @@ func (mr *MockcookieManagerMockRecorder) newAuthCookie(w, sameSiteStrict, sessio
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "newAuthCookie", reflect.TypeOf((*MockcookieManager)(nil).newAuthCookie), w, sameSiteStrict, sessionID)
 }
 
+// newAuthCookieWithDomain mocks base method.
+func (m *MockcookieManager) newAuthCookieWithDomain(w http.ResponseWriter, sameSiteStrict bool, sessionID ccc.UUID, domain string) (map[scKey]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "newAuthCookieWithDomain", w, sameSiteStrict, sessionID, domain)
+	ret0, _ := ret[0].(map[scKey]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// newAuthCookieWithDomain indicates an expected call of newAuthCookieWithDomain.
+func (mr *MockcookieManagerMockRecorder) newAuthCookieWithDomain(w, sameSiteStrict, sessionID, domain any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "newAuthCookieWithDomain", reflect.TypeOf((*MockcookieManager)(nil).newAuthCookieWithDomain), w, sameSiteStrict, sessionID, domain)
+}
+
 // readAuthCookie mocks base method.
 func (m *MockcookieManager) readAuthCookie(r *http.Request) (map[scKey]string, bool) {
 	m.ctrl.T.Helper()
@@ -111,4 +127,18 @@ func (m *MockcookieManager) writeAuthCookie(w http.ResponseWriter, sameSiteStric
 func (mr *MockcookieManagerMockRecorder) writeAuthCookie(w, sameSiteStrict, cval any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "writeAuthCookie", reflect.TypeOf((*MockcookieManager)(nil).writeAuthCookie), w, sameSiteStrict, cval)
+}
+
+// writeAuthCookieWithDomain mocks base method.
+func (m *MockcookieManager) writeAuthCookieWithDomain(w http.ResponseWriter, sameSiteStrict bool, cval map[scKey]string, domain string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "writeAuthCookieWithDomain", w, sameSiteStrict, cval, domain)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// writeAuthCookieWithDomain indicates an expected call of writeAuthCookieWithDomain.
+func (mr *MockcookieManagerMockRecorder) writeAuthCookieWithDomain(w, sameSiteStrict, cval, domain any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "writeAuthCookieWithDomain", reflect.TypeOf((*MockcookieManager)(nil).writeAuthCookieWithDomain), w, sameSiteStrict, cval, domain)
 }

--- a/preauth.go
+++ b/preauth.go
@@ -54,3 +54,25 @@ func (p *PreauthSession) NewSession(ctx context.Context, w http.ResponseWriter, 
 
 	return id, nil
 }
+
+// NewSessionWithDomain creates a new session and sets authentication cookies with a specified domain
+func (p *PreauthSession) NewSessionWithDomain(ctx context.Context, w http.ResponseWriter, r *http.Request, username string, domain string) (ccc.UUID, error) {
+	ctx, span := otel.Tracer(name).Start(ctx, "PreauthSession.NewSessionWithDomain()")
+	defer span.End()
+
+	// Create new Session in database
+	id, err := p.storage.NewSession(ctx, username)
+	if err != nil {
+		return ccc.NilUUID, errors.Wrap(err, "PreauthSessionStorage.NewSession()")
+	}
+
+	// Write new Auth Cookie with domain
+	if _, err := p.newAuthCookieWithDomain(w, false, id, domain); err != nil {
+		return ccc.NilUUID, err
+	}
+
+	// Write new XSRF Token Cookie to match the new SessionID
+	p.setXSRFTokenCookie(w, r, id, xsrfCookieLife)
+
+	return id, nil
+}

--- a/preauth.go
+++ b/preauth.go
@@ -56,7 +56,7 @@ func (p *PreauthSession) NewSession(ctx context.Context, w http.ResponseWriter, 
 }
 
 // NewSessionWithDomain creates a new session and sets authentication cookies with a specified domain
-func (p *PreauthSession) NewSessionWithDomain(ctx context.Context, w http.ResponseWriter, r *http.Request, username string, domain string) (ccc.UUID, error) {
+func (p *PreauthSession) NewSessionWithDomain(ctx context.Context, w http.ResponseWriter, r *http.Request, username, domain string) (ccc.UUID, error) {
 	ctx, span := otel.Tracer(name).Start(ctx, "PreauthSession.NewSessionWithDomain()")
 	defer span.End()
 

--- a/preauth_iface.go
+++ b/preauth_iface.go
@@ -1,7 +1,16 @@
 package session
 
+import (
+	"context"
+	"net/http"
+
+	"github.com/cccteam/ccc"
+)
+
 var _ PreAuthHandlers = &PreauthSession{}
 
 type PreAuthHandlers interface {
 	sessionHandlers
+	NewSession(ctx context.Context, w http.ResponseWriter, r *http.Request, username string) (ccc.UUID, error)
+	NewSessionWithDomain(ctx context.Context, w http.ResponseWriter, r *http.Request, username string, domain string) (ccc.UUID, error)
 }


### PR DESCRIPTION
I opted to add in extra functions so that the "Default" case of our package would be the more secure option where the domain is defaulted to the issuing domain. 

This way it didn't add any additional complexity for someone using this package as it was before this PR. 

I'm open to w/e you think may work better though. I have tested without these changes and it didn't work. After adding in these changes the browser handles it all perfectly. 