### PR TITLE
feat: Allow for Cookie Name and Domain 

### DIFF
--- a/cookies.go
+++ b/cookies.go
@@ -38,13 +38,13 @@ var _ cookieManager = &cookieClient{}
 
 type cookieClient struct {
 	secureCookie *securecookie.SecureCookie
-	cookiename   string
+	cookieName   string
 }
 
-func newCookieClient(secureCookie *securecookie.SecureCookie, cookiename string) *cookieClient {
+func newCookieClient(secureCookie *securecookie.SecureCookie, cookieName string) *cookieClient {
 	return &cookieClient{
 		secureCookie: secureCookie,
-		cookiename:   cookiename,
+		cookieName:   cookieName,
 	}
 }
 
@@ -64,11 +64,11 @@ func (c *cookieClient) newAuthCookie(w http.ResponseWriter, sameSiteStrict bool,
 func (c *cookieClient) readAuthCookie(r *http.Request) (map[scKey]string, bool) {
 	cval := make(map[scKey]string)
 
-	cookie, err := r.Cookie(c.cookiename)
+	cookie, err := r.Cookie(c.cookieName)
 	if err != nil {
 		return cval, false
 	}
-	err = c.secureCookie.Decode(c.cookiename, cookie.Value, &cval)
+	err = c.secureCookie.Decode(c.cookieName, cookie.Value, &cval)
 	if err != nil {
 		logger.Req(r).Error(errors.Wrap(err, "secureCookie.Decode()"))
 
@@ -80,7 +80,7 @@ func (c *cookieClient) readAuthCookie(r *http.Request) (map[scKey]string, bool) 
 
 func (c *cookieClient) writeAuthCookie(w http.ResponseWriter, sameSiteStrict bool, cval map[scKey]string, domain string) error {
 	cval[scSameSiteStrict] = strconv.FormatBool(sameSiteStrict)
-	encoded, err := c.secureCookie.Encode(c.cookiename, cval)
+	encoded, err := c.secureCookie.Encode(c.cookieName, cval)
 	if err != nil {
 		return errors.Wrap(err, "securecookie.Encode()")
 	}
@@ -91,7 +91,7 @@ func (c *cookieClient) writeAuthCookie(w http.ResponseWriter, sameSiteStrict boo
 	}
 
 	http.SetCookie(w, &http.Cookie{
-		Name:     c.cookiename,
+		Name:     c.cookieName,
 		Value:    encoded,
 		Path:     "/",
 		Domain:   domain,

--- a/cookies_test.go
+++ b/cookies_test.go
@@ -76,11 +76,12 @@ func Test_readAuthCookie(t *testing.T) {
 	t.Parallel()
 
 	sc := securecookie.New(securecookie.GenerateRandomKey(32), nil)
-	a := &session{cookieManager: &cookieClient{secureCookie: sc}}
+	a := &session{cookieManager: &cookieClient{secureCookie: sc, cookiename: string(scAuthCookieName)}}
 	w := httptest.NewRecorder()
 	cval := map[scKey]string{
-		"key1": "value1",
-		"key2": "value2",
+		"key1":           "value1",
+		"key2":           "value2",
+		scSameSiteStrict: "false",
 	}
 	if err := a.writeAuthCookie(w, false, cval, ""); err != nil {
 		t.Fatalf("writeAuthCookie() err = %v", err)
@@ -120,7 +121,7 @@ func Test_readAuthCookie(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			app := &session{cookieManager: &cookieClient{secureCookie: tt.sc}}
+			app := &session{cookieManager: &cookieClient{secureCookie: tt.sc, cookiename: string(scAuthCookieName)}}
 			got, got1 := app.readAuthCookie(tt.req)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("readAuthCookie() got = %v, want %v", got, tt.want)
@@ -183,8 +184,8 @@ func Test_writeAuthCookie(t *testing.T) {
 				return
 			}
 
-			if secure := strings.Contains(w.Header().Get("Set-Cookie"), "; Secure"); secure != true {
-				t.Errorf("Secure: %v, want Secure: %v", secure, true)
+			if secure := strings.Contains(w.Header().Get("Set-Cookie"), "; Secure"); secure != secureCookie() {
+				t.Errorf("Secure: %v, want Secure: %v", secure, secureCookie())
 			}
 			if sameSiteStrict := strings.Contains(w.Header().Get("Set-Cookie"), "; SameSite=Strict"); sameSiteStrict != tt.sameSiteStrict {
 				t.Errorf("SameSiteStrict: %v, want SameSiteStrict: %v", sameSiteStrict, tt.sameSiteStrict)

--- a/cookies_test.go
+++ b/cookies_test.go
@@ -50,7 +50,7 @@ func Test_newAuthCookie(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			a := &session{cookieManager: &cookieClient{secureCookie: tt.sc, cookiename: string(scAuthCookieName)}}
+			a := &session{cookieManager: &cookieClient{secureCookie: tt.sc, cookieName: string(scAuthCookieName)}}
 
 			w := httptest.NewRecorder()
 			got, err := a.newAuthCookie(w, tt.args.sameSiteStrict, ccc.UUID{}, "")
@@ -80,7 +80,7 @@ func Test_readAuthCookie(t *testing.T) {
 	t.Parallel()
 
 	sc := securecookie.New(securecookie.GenerateRandomKey(32), nil)
-	a := &session{cookieManager: &cookieClient{secureCookie: sc, cookiename: string(scAuthCookieName)}}
+	a := &session{cookieManager: &cookieClient{secureCookie: sc, cookieName: string(scAuthCookieName)}}
 	w := httptest.NewRecorder()
 	cval := map[scKey]string{
 		"key1":           "value1",
@@ -125,7 +125,7 @@ func Test_readAuthCookie(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			app := &session{cookieManager: &cookieClient{secureCookie: tt.sc, cookiename: string(scAuthCookieName)}}
+			app := &session{cookieManager: &cookieClient{secureCookie: tt.sc, cookieName: string(scAuthCookieName)}}
 			got, got1 := app.readAuthCookie(tt.req)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("readAuthCookie() got = %v, want %v", got, tt.want)
@@ -178,7 +178,7 @@ func Test_writeAuthCookie(t *testing.T) {
 				"key1": "value1",
 				"key2": "value2",
 			}
-			a := &session{cookieManager: &cookieClient{secureCookie: tt.fields.sc, cookiename: string(scAuthCookieName)}}
+			a := &session{cookieManager: &cookieClient{secureCookie: tt.fields.sc, cookieName: string(scAuthCookieName)}}
 			w := httptest.NewRecorder()
 
 			if err := a.writeAuthCookie(w, tt.sameSiteStrict, cval, ""); (err != nil) != tt.wantWriteErr {

--- a/cookies_test.go
+++ b/cookies_test.go
@@ -53,7 +53,7 @@ func Test_newAuthCookie(t *testing.T) {
 			a := &session{cookieManager: &cookieClient{secureCookie: tt.sc}}
 
 			w := httptest.NewRecorder()
-			got, err := a.newAuthCookie(w, tt.args.sameSiteStrict, ccc.UUID{})
+			got, err := a.newAuthCookie(w, tt.args.sameSiteStrict, ccc.UUID{}, "")
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("newAuthCookie() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -82,7 +82,7 @@ func Test_readAuthCookie(t *testing.T) {
 		"key1": "value1",
 		"key2": "value2",
 	}
-	if err := a.writeAuthCookie(w, false, cval); err != nil {
+	if err := a.writeAuthCookie(w, false, cval, ""); err != nil {
 		t.Fatalf("writeAuthCookie() err = %v", err)
 	}
 	// Copy the Cookie over to a new Request
@@ -176,7 +176,7 @@ func Test_writeAuthCookie(t *testing.T) {
 			a := &session{cookieManager: &cookieClient{secureCookie: tt.fields.sc}}
 			w := httptest.NewRecorder()
 
-			if err := a.writeAuthCookie(w, tt.sameSiteStrict, cval); (err != nil) != tt.wantWriteErr {
+			if err := a.writeAuthCookie(w, tt.sameSiteStrict, cval, ""); (err != nil) != tt.wantWriteErr {
 				t.Errorf("writeAuthCookie() error = %v, wantErr %v", err, tt.wantWriteErr)
 			}
 			if tt.wantWriteErr {

--- a/cookies_test_build.go
+++ b/cookies_test_build.go
@@ -1,0 +1,6 @@
+//go:build !insecurecookie
+
+package session
+
+// Using this to ensure tests run with secure cookie settings
+// In test environment, we want to verify that cookies have the Secure flag set to true

--- a/mock_cookies_test.go
+++ b/mock_cookies_test.go
@@ -57,33 +57,18 @@ func (mr *MockcookieManagerMockRecorder) hasValidXSRFToken(r any) *gomock.Call {
 }
 
 // newAuthCookie mocks base method.
-func (m *MockcookieManager) newAuthCookie(w http.ResponseWriter, sameSiteStrict bool, sessionID ccc.UUID) (map[scKey]string, error) {
+func (m *MockcookieManager) newAuthCookie(w http.ResponseWriter, sameSiteStrict bool, sessionID ccc.UUID, domain string) (map[scKey]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "newAuthCookie", w, sameSiteStrict, sessionID)
+	ret := m.ctrl.Call(m, "newAuthCookie", w, sameSiteStrict, sessionID, domain)
 	ret0, _ := ret[0].(map[scKey]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // newAuthCookie indicates an expected call of newAuthCookie.
-func (mr *MockcookieManagerMockRecorder) newAuthCookie(w, sameSiteStrict, sessionID any) *gomock.Call {
+func (mr *MockcookieManagerMockRecorder) newAuthCookie(w, sameSiteStrict, sessionID, domain any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "newAuthCookie", reflect.TypeOf((*MockcookieManager)(nil).newAuthCookie), w, sameSiteStrict, sessionID)
-}
-
-// newAuthCookieWithDomain mocks base method.
-func (m *MockcookieManager) newAuthCookieWithDomain(w http.ResponseWriter, sameSiteStrict bool, sessionID ccc.UUID, domain string) (map[scKey]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "newAuthCookieWithDomain", w, sameSiteStrict, sessionID, domain)
-	ret0, _ := ret[0].(map[scKey]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// newAuthCookieWithDomain indicates an expected call of newAuthCookieWithDomain.
-func (mr *MockcookieManagerMockRecorder) newAuthCookieWithDomain(w, sameSiteStrict, sessionID, domain any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "newAuthCookieWithDomain", reflect.TypeOf((*MockcookieManager)(nil).newAuthCookieWithDomain), w, sameSiteStrict, sessionID, domain)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "newAuthCookie", reflect.TypeOf((*MockcookieManager)(nil).newAuthCookie), w, sameSiteStrict, sessionID, domain)
 }
 
 // readAuthCookie mocks base method.
@@ -116,29 +101,15 @@ func (mr *MockcookieManagerMockRecorder) setXSRFTokenCookie(w, r, sessionID, coo
 }
 
 // writeAuthCookie mocks base method.
-func (m *MockcookieManager) writeAuthCookie(w http.ResponseWriter, sameSiteStrict bool, cval map[scKey]string) error {
+func (m *MockcookieManager) writeAuthCookie(w http.ResponseWriter, sameSiteStrict bool, cval map[scKey]string, domain string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "writeAuthCookie", w, sameSiteStrict, cval)
+	ret := m.ctrl.Call(m, "writeAuthCookie", w, sameSiteStrict, cval, domain)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // writeAuthCookie indicates an expected call of writeAuthCookie.
-func (mr *MockcookieManagerMockRecorder) writeAuthCookie(w, sameSiteStrict, cval any) *gomock.Call {
+func (mr *MockcookieManagerMockRecorder) writeAuthCookie(w, sameSiteStrict, cval, domain any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "writeAuthCookie", reflect.TypeOf((*MockcookieManager)(nil).writeAuthCookie), w, sameSiteStrict, cval)
-}
-
-// writeAuthCookieWithDomain mocks base method.
-func (m *MockcookieManager) writeAuthCookieWithDomain(w http.ResponseWriter, sameSiteStrict bool, cval map[scKey]string, domain string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "writeAuthCookieWithDomain", w, sameSiteStrict, cval, domain)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// writeAuthCookieWithDomain indicates an expected call of writeAuthCookieWithDomain.
-func (mr *MockcookieManagerMockRecorder) writeAuthCookieWithDomain(w, sameSiteStrict, cval, domain any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "writeAuthCookieWithDomain", reflect.TypeOf((*MockcookieManager)(nil).writeAuthCookieWithDomain), w, sameSiteStrict, cval, domain)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "writeAuthCookie", reflect.TypeOf((*MockcookieManager)(nil).writeAuthCookie), w, sameSiteStrict, cval, domain)
 }

--- a/oidc.go
+++ b/oidc.go
@@ -29,7 +29,7 @@ type OIDCAzureSession struct {
 
 func NewOIDCAzure(
 	oidcAuthenticator oidc.Authenticator, oidcSession OIDCAzureSessionStorage, userManager UserManager,
-	logHandler LogHandler, secureCookie *securecookie.SecureCookie, sessionTimeout time.Duration,
+	logHandler LogHandler, secureCookie *securecookie.SecureCookie, sessionTimeout time.Duration, cookiename string,
 ) *OIDCAzureSession {
 	return &OIDCAzureSession{
 		userManager: userManager,
@@ -37,7 +37,7 @@ func NewOIDCAzure(
 		session: session{
 			perms:          userManager,
 			handle:         logHandler,
-			cookieManager:  newCookieClient(secureCookie),
+			cookieManager:  newCookieClient(secureCookie, cookiename),
 			sessionTimeout: sessionTimeout,
 			storage:        oidcSession,
 		},

--- a/oidc.go
+++ b/oidc.go
@@ -184,7 +184,7 @@ func (o *OIDCAzureSession) startNewSession(ctx context.Context, w http.ResponseW
 		return ccc.NilUUID, errors.Wrap(err, "OIDCAzureSessionStorage.NewSession()")
 	}
 
-	if _, err := o.newAuthCookie(w, false, id); err != nil {
+	if _, err := o.newAuthCookie(w, false, id, ""); err != nil {
 		return ccc.NilUUID, err
 	}
 

--- a/oidc.go
+++ b/oidc.go
@@ -29,7 +29,7 @@ type OIDCAzureSession struct {
 
 func NewOIDCAzure(
 	oidcAuthenticator oidc.Authenticator, oidcSession OIDCAzureSessionStorage, userManager UserManager,
-	logHandler LogHandler, secureCookie *securecookie.SecureCookie, sessionTimeout time.Duration, cookiename string,
+	logHandler LogHandler, secureCookie *securecookie.SecureCookie, sessionTimeout time.Duration, cookieName string,
 ) *OIDCAzureSession {
 	return &OIDCAzureSession{
 		userManager: userManager,
@@ -37,7 +37,7 @@ func NewOIDCAzure(
 		session: session{
 			perms:          userManager,
 			handle:         logHandler,
-			cookieManager:  newCookieClient(secureCookie, cookiename),
+			cookieManager:  newCookieClient(secureCookie, cookieName),
 			sessionTimeout: sessionTimeout,
 			storage:        oidcSession,
 		},

--- a/oidc_test.go
+++ b/oidc_test.go
@@ -134,7 +134,7 @@ func TestApp_CallbackOIDC(t *testing.T) {
 				oidc.EXPECT().LoginURL().Return("/login").Times(1)
 				oidc.EXPECT().Verify(gomock.Any(), w, r, gomock.Any()).Return("testReturnUrl", "a test SID value", nil).Times(1)
 				s.EXPECT().NewSession(gomock.Any(), gomock.Any(), gomock.Any()).Return(ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5")), nil).Times(1)
-				c.EXPECT().newAuthCookie(w, false, ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5"))).Return(map[scKey]string{scSessionID: "de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5"}, errors.New("failed to create new auth cookie")).Times(1)
+				c.EXPECT().newAuthCookie(w, false, ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5")), "").Return(map[scKey]string{scSessionID: "de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5"}, errors.New("failed to create new auth cookie")).Times(1)
 			},
 			wantRedirectURL: fmt.Sprintf("/login?message=%s", url.QueryEscape("Internal Server Error")),
 			wantErr:         true,
@@ -145,7 +145,7 @@ func TestApp_CallbackOIDC(t *testing.T) {
 				oidc.EXPECT().LoginURL().Return("/login").Times(1)
 				oidc.EXPECT().Verify(gomock.Any(), w, r, gomock.Any()).Return("testReturnUrl", "a test SID value", nil).Times(1)
 				s.EXPECT().NewSession(gomock.Any(), gomock.Any(), gomock.Any()).Return(ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5")), nil).Times(1)
-				c.EXPECT().newAuthCookie(w, false, ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5"))).Return(map[scKey]string{scSessionID: "de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5"}, nil).Times(1)
+				c.EXPECT().newAuthCookie(w, false, ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5")), "").Return(map[scKey]string{scSessionID: "de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5"}, nil).Times(1)
 				c.EXPECT().setXSRFTokenCookie(w, r, ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5")), xsrfCookieLife).Return(true).Times(1)
 				u.EXPECT().Domains(gomock.Any()).Return(nil, errors.New("failed to get domains")).Times(1)
 			},
@@ -165,7 +165,7 @@ func TestApp_CallbackOIDC(t *testing.T) {
 						return "testReturnUrl", "a test SID value", nil
 					}).Times(1)
 				s.EXPECT().NewSession(gomock.Any(), gomock.Any(), gomock.Any()).Return(ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5")), nil).Times(1)
-				c.EXPECT().newAuthCookie(w, false, ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5"))).Return(map[scKey]string{scSessionID: "de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5"}, nil).Times(1)
+				c.EXPECT().newAuthCookie(w, false, ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5")), "").Return(map[scKey]string{scSessionID: "de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5"}, nil).Times(1)
 				c.EXPECT().setXSRFTokenCookie(w, r, ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5")), xsrfCookieLife).Return(true).Times(1)
 				u.EXPECT().Domains(gomock.Any()).Return([]accesstypes.Domain{"testDomain1", "test domain 2"}, nil).Times(1)
 				u.EXPECT().UserRoles(gomock.Any(), accesstypes.User("test username"), []accesstypes.Domain{"testDomain1", "test domain 2"}).Return(nil, errors.New("failed to get user roles")).Times(1)
@@ -186,7 +186,7 @@ func TestApp_CallbackOIDC(t *testing.T) {
 						return "testReturnUrl", "a test SID value", nil
 					}).Times(1)
 				s.EXPECT().NewSession(gomock.Any(), gomock.Any(), gomock.Any()).Return(ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5")), nil).Times(1)
-				c.EXPECT().newAuthCookie(w, false, ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5"))).Return(map[scKey]string{scSessionID: "de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5"}, nil).Times(1)
+				c.EXPECT().newAuthCookie(w, false, ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5")), "").Return(map[scKey]string{scSessionID: "de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5"}, nil).Times(1)
 				c.EXPECT().setXSRFTokenCookie(w, r, ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5")), xsrfCookieLife).Return(true).Times(1)
 				u.EXPECT().Domains(gomock.Any()).Return([]accesstypes.Domain{"testDomain1", "test domain 2"}, nil).Times(1)
 				u.EXPECT().UserRoles(gomock.Any(), accesstypes.User("test username"), []accesstypes.Domain{"testDomain1", "test domain 2"}).Return(map[accesstypes.Domain][]accesstypes.Role{
@@ -212,7 +212,7 @@ func TestApp_CallbackOIDC(t *testing.T) {
 						return "testReturnUrl", "a test SID value", nil
 					}).Times(1)
 				s.EXPECT().NewSession(gomock.Any(), gomock.Any(), gomock.Any()).Return(ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5")), nil).Times(1)
-				c.EXPECT().newAuthCookie(w, false, ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5"))).Return(map[scKey]string{scSessionID: "de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5"}, nil).Times(1)
+				c.EXPECT().newAuthCookie(w, false, ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5")), "").Return(map[scKey]string{scSessionID: "de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5"}, nil).Times(1)
 				c.EXPECT().setXSRFTokenCookie(w, r, ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5")), xsrfCookieLife).Return(true).Times(1)
 				u.EXPECT().Domains(gomock.Any()).Return([]accesstypes.Domain{"testDomain1", "test domain 2"}, nil).Times(1)
 				u.EXPECT().UserRoles(gomock.Any(), accesstypes.User("test username"), []accesstypes.Domain{"testDomain1", "test domain 2"}).Return(map[accesstypes.Domain][]accesstypes.Role{
@@ -239,7 +239,7 @@ func TestApp_CallbackOIDC(t *testing.T) {
 						return "testReturnUrl", "a test SID value", nil
 					}).Times(1)
 				s.EXPECT().NewSession(gomock.Any(), gomock.Any(), gomock.Any()).Return(ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5")), nil).Times(1)
-				c.EXPECT().newAuthCookie(w, false, ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5"))).Return(map[scKey]string{scSessionID: "de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5"}, nil).Times(1)
+				c.EXPECT().newAuthCookie(w, false, ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5")), "").Return(map[scKey]string{scSessionID: "de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5"}, nil).Times(1)
 				c.EXPECT().setXSRFTokenCookie(w, r, ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5")), xsrfCookieLife).Return(true).Times(1)
 				u.EXPECT().Domains(gomock.Any()).Return([]accesstypes.Domain{"testDomain1", "test domain 2"}, nil).Times(1)
 				u.EXPECT().UserRoles(gomock.Any(), accesstypes.User("test username"), []accesstypes.Domain{"testDomain1", "test domain 2"}).Return(map[accesstypes.Domain][]accesstypes.Role{
@@ -265,7 +265,7 @@ func TestApp_CallbackOIDC(t *testing.T) {
 						return "testReturnUrl", "a test SID value", nil
 					}).Times(1)
 				s.EXPECT().NewSession(gomock.Any(), gomock.Any(), gomock.Any()).Return(ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5")), nil).Times(1)
-				c.EXPECT().newAuthCookie(w, false, ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5"))).Return(map[scKey]string{scSessionID: "de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5"}, nil).Times(1)
+				c.EXPECT().newAuthCookie(w, false, ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5")), "").Return(map[scKey]string{scSessionID: "de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5"}, nil).Times(1)
 				c.EXPECT().setXSRFTokenCookie(w, r, ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5")), xsrfCookieLife).Return(true).Times(1)
 				u.EXPECT().Domains(gomock.Any()).Return([]accesstypes.Domain{"testDomain1", "test domain 2"}, nil).Times(1)
 				u.EXPECT().UserRoles(gomock.Any(), accesstypes.User("test username"), []accesstypes.Domain{"testDomain1", "test domain 2"}).Return(map[accesstypes.Domain][]accesstypes.Role{

--- a/preauth.go
+++ b/preauth.go
@@ -20,13 +20,13 @@ type PreauthSession struct {
 
 func NewPreauth(
 	preauthSession PreauthSessionStorage, userPermissionManager UserPermissionManager,
-	logHandler LogHandler, secureCookie *securecookie.SecureCookie, sessionTimeout time.Duration,
+	logHandler LogHandler, secureCookie *securecookie.SecureCookie, sessionTimeout time.Duration, cookiename string,
 ) *PreauthSession {
 	return &PreauthSession{
 		session: session{
 			perms:          userPermissionManager,
 			handle:         logHandler,
-			cookieManager:  newCookieClient(secureCookie),
+			cookieManager:  newCookieClient(secureCookie, cookiename),
 			sessionTimeout: sessionTimeout,
 			storage:        preauthSession,
 		},

--- a/preauth.go
+++ b/preauth.go
@@ -20,14 +20,14 @@ type PreauthSession struct {
 
 func NewPreauth(
 	preauthSession PreauthSessionStorage, userPermissionManager UserPermissionManager,
-	logHandler LogHandler, secureCookie *securecookie.SecureCookie, sessionTimeout time.Duration, cookiename string,
+	logHandler LogHandler, secureCookie *securecookie.SecureCookie, sessionTimeout time.Duration, cookieName string,
 	domain string,
 ) *PreauthSession {
 	return &PreauthSession{
 		session: session{
 			perms:          userPermissionManager,
 			handle:         logHandler,
-			cookieManager:  newCookieClient(secureCookie, cookiename),
+			cookieManager:  newCookieClient(secureCookie, cookieName),
 			sessionTimeout: sessionTimeout,
 			storage:        preauthSession,
 			domain:         domain,

--- a/preauth.go
+++ b/preauth.go
@@ -21,6 +21,7 @@ type PreauthSession struct {
 func NewPreauth(
 	preauthSession PreauthSessionStorage, userPermissionManager UserPermissionManager,
 	logHandler LogHandler, secureCookie *securecookie.SecureCookie, sessionTimeout time.Duration, cookiename string,
+	domain string,
 ) *PreauthSession {
 	return &PreauthSession{
 		session: session{
@@ -29,13 +30,14 @@ func NewPreauth(
 			cookieManager:  newCookieClient(secureCookie, cookiename),
 			sessionTimeout: sessionTimeout,
 			storage:        preauthSession,
+			domain:         domain,
 		},
 		storage: preauthSession,
 	}
 }
 
 func (p *PreauthSession) NewSession(ctx context.Context, w http.ResponseWriter, r *http.Request, username string) (ccc.UUID, error) {
-	ctx, span := otel.Tracer(name).Start(ctx, "PreauthSession.NewSession()")
+	ctx, span := otel.Tracer(name).Start(ctx, "PreauthSession.NewSessions()")
 	defer span.End()
 
 	// Create new Session in database
@@ -45,29 +47,7 @@ func (p *PreauthSession) NewSession(ctx context.Context, w http.ResponseWriter, 
 	}
 
 	// Write new Auth Cookie
-	if _, err := p.newAuthCookie(w, false, id); err != nil {
-		return ccc.NilUUID, err
-	}
-
-	// Write new XSRF Token Cookie to match the new SessionID
-	p.setXSRFTokenCookie(w, r, id, xsrfCookieLife)
-
-	return id, nil
-}
-
-// NewSessionWithDomain creates a new session and sets authentication cookies with a specified domain
-func (p *PreauthSession) NewSessionWithDomain(ctx context.Context, w http.ResponseWriter, r *http.Request, username, domain string) (ccc.UUID, error) {
-	ctx, span := otel.Tracer(name).Start(ctx, "PreauthSession.NewSessionWithDomain()")
-	defer span.End()
-
-	// Create new Session in database
-	id, err := p.storage.NewSession(ctx, username)
-	if err != nil {
-		return ccc.NilUUID, errors.Wrap(err, "PreauthSessionStorage.NewSession()")
-	}
-
-	// Write new Auth Cookie with domain
-	if _, err := p.newAuthCookieWithDomain(w, false, id, domain); err != nil {
+	if _, err := p.newAuthCookie(w, false, id, p.domain); err != nil {
 		return ccc.NilUUID, err
 	}
 

--- a/preauth.go
+++ b/preauth.go
@@ -37,7 +37,7 @@ func NewPreauth(
 }
 
 func (p *PreauthSession) NewSession(ctx context.Context, w http.ResponseWriter, r *http.Request, username string) (ccc.UUID, error) {
-	ctx, span := otel.Tracer(name).Start(ctx, "PreauthSession.NewSessions()")
+	ctx, span := otel.Tracer(name).Start(ctx, "PreauthSession.NewSession()")
 	defer span.End()
 
 	// Create new Session in database

--- a/preauth_iface.go
+++ b/preauth_iface.go
@@ -12,5 +12,4 @@ var _ PreAuthHandlers = &PreauthSession{}
 type PreAuthHandlers interface {
 	sessionHandlers
 	NewSession(ctx context.Context, w http.ResponseWriter, r *http.Request, username string) (ccc.UUID, error)
-	NewSessionWithDomain(ctx context.Context, w http.ResponseWriter, r *http.Request, username string, domain string) (ccc.UUID, error)
 }

--- a/preauth_test.go
+++ b/preauth_test.go
@@ -34,7 +34,7 @@ func TestPreauthSession_NewSession(t *testing.T) {
 
 				// Simulate cookie setting
 				mockCookies.EXPECT().
-					newAuthCookie(gomock.Any(), false, gomock.Any()).
+					newAuthCookie(gomock.Any(), false, gomock.Any(), gomock.Any()).
 					DoAndReturn(func(w http.ResponseWriter, _ bool, sessionID ccc.UUID) (map[scKey]string, error) {
 						http.SetCookie(w, &http.Cookie{
 							Name:  "auth",
@@ -76,7 +76,7 @@ func TestPreauthSession_NewSession(t *testing.T) {
 
 				// Simulate failure in setting the auth cookie
 				mockCookies.EXPECT().
-					newAuthCookie(gomock.Any(), false, gomock.Any()).
+					newAuthCookie(gomock.Any(), false, gomock.Any(), gomock.Any()).
 					Return(nil, errors.New("failed to set auth cookie")).
 					Times(1)
 			},

--- a/preauth_test.go
+++ b/preauth_test.go
@@ -35,7 +35,7 @@ func TestPreauthSession_NewSession(t *testing.T) {
 				// Simulate cookie setting
 				mockCookies.EXPECT().
 					newAuthCookie(gomock.Any(), false, gomock.Any(), gomock.Any()).
-					DoAndReturn(func(w http.ResponseWriter, _ bool, sessionID ccc.UUID) (map[scKey]string, error) {
+					DoAndReturn(func(w http.ResponseWriter, _ bool, sessionID ccc.UUID, _ string) (map[scKey]string, error) {
 						http.SetCookie(w, &http.Cookie{
 							Name:  "auth",
 							Value: sessionID.String(),

--- a/session.go
+++ b/session.go
@@ -25,6 +25,7 @@ type session struct {
 	handle         LogHandler
 	storage        storageManager
 	cookieManager
+	domain string
 }
 
 // SetSessionTimeout is a Handler to set the session timeout
@@ -68,7 +69,7 @@ func (s *session) StartSession(next http.Handler) http.Handler {
 			if err != nil {
 				return httpio.NewEncoder(w).ClientMessage(ctx, err)
 			}
-			cval, err = s.newAuthCookie(w, true, sessionID)
+			cval, err = s.newAuthCookie(w, true, sessionID, s.domain)
 			if err != nil {
 				return httpio.NewEncoder(w).ClientMessage(ctx, err)
 			}
@@ -77,7 +78,7 @@ func (s *session) StartSession(next http.Handler) http.Handler {
 		// Upgrade cookie to SameSite=Strict
 		// since CallbackOIDC() sets it to None to allow OAuth flow to work
 		if cval[scSameSiteStrict] != strconv.FormatBool(true) {
-			if err := s.writeAuthCookie(w, true, cval); err != nil {
+			if err := s.writeAuthCookie(w, true, cval, s.domain); err != nil {
 				return httpio.NewEncoder(w).ClientMessage(ctx, err)
 			}
 		}

--- a/session_test.go
+++ b/session_test.go
@@ -132,7 +132,7 @@ func TestAppStartSession(t *testing.T) {
 					scSameSiteStrict: "true",
 				}, true)
 				c.EXPECT().newAuthCookie(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Do(func(_ http.ResponseWriter, _ bool, sessionID ccc.UUID) {
+					Do(func(_ http.ResponseWriter, _ bool, sessionID ccc.UUID, _ string) {
 						tt.wantSessionID = sessionID
 					}).
 					Return(map[scKey]string{
@@ -148,7 +148,7 @@ func TestAppStartSession(t *testing.T) {
 			prepare: func(c *MockcookieManager, tt *test) {
 				c.EXPECT().readAuthCookie(gomock.Any()).Return(nil, false)
 				c.EXPECT().newAuthCookie(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Do(func(_ http.ResponseWriter, _ bool, sessionID ccc.UUID) {
+					Do(func(_ http.ResponseWriter, _ bool, sessionID ccc.UUID, _ string) {
 						tt.wantSessionID = sessionID
 					}).
 					Return(map[scKey]string{

--- a/session_test.go
+++ b/session_test.go
@@ -49,7 +49,7 @@ func mockRequestWithSession(ctx context.Context, t *testing.T, method string, sc
 		}
 
 		a := &session{cookieManager: &cookieClient{secureCookie: sc}}
-		if _, err := a.newAuthCookie(w, false, id); err != nil {
+		if _, err := a.newAuthCookie(w, false, id, ""); err != nil {
 			t.Fatalf("newAuthCookie() = %v", err)
 		}
 
@@ -131,7 +131,7 @@ func TestAppStartSession(t *testing.T) {
 					scSessionID:      "92922509-82d2-4ba-853a-d73b8926a55f",
 					scSameSiteStrict: "true",
 				}, true)
-				c.EXPECT().newAuthCookie(gomock.Any(), gomock.Any(), gomock.Any()).
+				c.EXPECT().newAuthCookie(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Do(func(_ http.ResponseWriter, _ bool, sessionID ccc.UUID) {
 						tt.wantSessionID = sessionID
 					}).
@@ -147,7 +147,7 @@ func TestAppStartSession(t *testing.T) {
 			req:  mockRequestWithSession(context.Background(), t, http.MethodGet, securecookie.New(securecookie.GenerateRandomKey(32), nil), "", time.Second*5),
 			prepare: func(c *MockcookieManager, tt *test) {
 				c.EXPECT().readAuthCookie(gomock.Any()).Return(nil, false)
-				c.EXPECT().newAuthCookie(gomock.Any(), gomock.Any(), gomock.Any()).
+				c.EXPECT().newAuthCookie(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Do(func(_ http.ResponseWriter, _ bool, sessionID ccc.UUID) {
 						tt.wantSessionID = sessionID
 					}).
@@ -167,7 +167,7 @@ func TestAppStartSession(t *testing.T) {
 				}, true)
 				c.EXPECT().writeAuthCookie(gomock.Any(), true, map[scKey]string{
 					scSessionID: "92922509-82d2-4bc7-853a-d73b8926a55f",
-				}).Return(nil)
+				}, "").Return(nil)
 			},
 			wantSessionID:  ccc.Must(ccc.UUIDFromString("92922509-82d2-4bc7-853a-d73b8926a55f")),
 			expectedStatus: http.StatusOK,
@@ -195,7 +195,7 @@ func TestAppStartSession(t *testing.T) {
 				c.EXPECT().writeAuthCookie(gomock.Any(), true, map[scKey]string{
 					scSessionID:      "92922509-82d2-4bc7-853a-d73b8926a55f",
 					scSameSiteStrict: "false",
-				}).Return(errors.New("error writing cookie"))
+				}, "").Return(errors.New("error writing cookie"))
 			},
 			expectedStatus: http.StatusInternalServerError,
 		},
@@ -204,7 +204,7 @@ func TestAppStartSession(t *testing.T) {
 			req:  &http.Request{URL: &url.URL{}},
 			prepare: func(c *MockcookieManager, _ *test) {
 				c.EXPECT().readAuthCookie(gomock.Any()).Return(nil, false)
-				c.EXPECT().newAuthCookie(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("error creating cookie"))
+				c.EXPECT().newAuthCookie(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("error creating cookie"))
 			},
 			expectedStatus: http.StatusInternalServerError,
 		},

--- a/xsrf_test.go
+++ b/xsrf_test.go
@@ -380,9 +380,9 @@ func Test_writeXSRFCookie(t *testing.T) {
 				return
 			}
 
-			if secure := strings.Contains(w.Header().Get("Set-Cookie"), "; Secure"); secure != true {
+			if secure := strings.Contains(w.Header().Get("Set-Cookie"), "; Secure"); secure != secureCookie() {
 				fmt.Println("The value is: ", w.Header().Get("Set-Cookie"))
-				t.Errorf("Secure = %v, wantSecure %v", secure, true)
+				t.Errorf("Secure = %v, wantSecure %v", secure, secureCookie())
 			}
 		})
 	}

--- a/xsrf_test.go
+++ b/xsrf_test.go
@@ -381,7 +381,6 @@ func Test_writeXSRFCookie(t *testing.T) {
 			}
 
 			if secure := strings.Contains(w.Header().Get("Set-Cookie"), "; Secure"); secure != secureCookie() {
-				fmt.Println("The value is: ", w.Header().Get("Set-Cookie"))
 				t.Errorf("Secure = %v, wantSecure %v", secure, secureCookie())
 			}
 		})


### PR DESCRIPTION
Not being able to specify cookie name and domain was causing clobbering and stacking up of the cookies between DLE and DLH. 

This PR allows me to specify the `.tst.ascendium.app` domain in environments rather than `dlh.tst.ascendium.app` that we were using by default before .

This also lets me seperate the oidc flow in DLE to be "oidc_auth" as the name instead of just "auth" so we aren't overwriting and clobbering those too. 

I've tested a lot with this build and it does in fact solve the issues between DLE and DLH. 