### PR TITLE
feature: Allow for Optioned Domain Name and Cookie Name

### DIFF
--- a/cookies_test.go
+++ b/cookies_test.go
@@ -53,7 +53,7 @@ func Test_newAuthCookie(t *testing.T) {
 			a := &session{cookieManager: &cookieClient{secureCookie: tt.sc, cookieName: string(scAuthCookieName)}}
 
 			w := httptest.NewRecorder()
-			got, err := a.newAuthCookie(w, tt.args.sameSiteStrict, ccc.UUID{}, "")
+			got, err := a.newAuthCookie(w, tt.args.sameSiteStrict, ccc.UUID{})
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("newAuthCookie() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -87,7 +87,7 @@ func Test_readAuthCookie(t *testing.T) {
 		"key2":           "value2",
 		scSameSiteStrict: "false",
 	}
-	if err := a.writeAuthCookie(w, false, cval, ""); err != nil {
+	if err := a.writeAuthCookie(w, false, cval); err != nil {
 		t.Fatalf("writeAuthCookie() err = %v", err)
 	}
 	// Copy the Cookie over to a new Request
@@ -181,7 +181,7 @@ func Test_writeAuthCookie(t *testing.T) {
 			a := &session{cookieManager: &cookieClient{secureCookie: tt.fields.sc, cookieName: string(scAuthCookieName)}}
 			w := httptest.NewRecorder()
 
-			if err := a.writeAuthCookie(w, tt.sameSiteStrict, cval, ""); (err != nil) != tt.wantWriteErr {
+			if err := a.writeAuthCookie(w, tt.sameSiteStrict, cval); (err != nil) != tt.wantWriteErr {
 				t.Errorf("writeAuthCookie() error = %v, wantErr %v", err, tt.wantWriteErr)
 			}
 			if tt.wantWriteErr {

--- a/mock_cookies_test.go
+++ b/mock_cookies_test.go
@@ -57,18 +57,18 @@ func (mr *MockcookieManagerMockRecorder) hasValidXSRFToken(r any) *gomock.Call {
 }
 
 // newAuthCookie mocks base method.
-func (m *MockcookieManager) newAuthCookie(w http.ResponseWriter, sameSiteStrict bool, sessionID ccc.UUID, domain string) (map[scKey]string, error) {
+func (m *MockcookieManager) newAuthCookie(w http.ResponseWriter, sameSiteStrict bool, sessionID ccc.UUID) (map[scKey]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "newAuthCookie", w, sameSiteStrict, sessionID, domain)
+	ret := m.ctrl.Call(m, "newAuthCookie", w, sameSiteStrict, sessionID)
 	ret0, _ := ret[0].(map[scKey]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // newAuthCookie indicates an expected call of newAuthCookie.
-func (mr *MockcookieManagerMockRecorder) newAuthCookie(w, sameSiteStrict, sessionID, domain any) *gomock.Call {
+func (mr *MockcookieManagerMockRecorder) newAuthCookie(w, sameSiteStrict, sessionID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "newAuthCookie", reflect.TypeOf((*MockcookieManager)(nil).newAuthCookie), w, sameSiteStrict, sessionID, domain)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "newAuthCookie", reflect.TypeOf((*MockcookieManager)(nil).newAuthCookie), w, sameSiteStrict, sessionID)
 }
 
 // readAuthCookie mocks base method.
@@ -101,15 +101,15 @@ func (mr *MockcookieManagerMockRecorder) setXSRFTokenCookie(w, r, sessionID, coo
 }
 
 // writeAuthCookie mocks base method.
-func (m *MockcookieManager) writeAuthCookie(w http.ResponseWriter, sameSiteStrict bool, cval map[scKey]string, domain string) error {
+func (m *MockcookieManager) writeAuthCookie(w http.ResponseWriter, sameSiteStrict bool, cval map[scKey]string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "writeAuthCookie", w, sameSiteStrict, cval, domain)
+	ret := m.ctrl.Call(m, "writeAuthCookie", w, sameSiteStrict, cval)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // writeAuthCookie indicates an expected call of writeAuthCookie.
-func (mr *MockcookieManagerMockRecorder) writeAuthCookie(w, sameSiteStrict, cval, domain any) *gomock.Call {
+func (mr *MockcookieManagerMockRecorder) writeAuthCookie(w, sameSiteStrict, cval any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "writeAuthCookie", reflect.TypeOf((*MockcookieManager)(nil).writeAuthCookie), w, sameSiteStrict, cval, domain)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "writeAuthCookie", reflect.TypeOf((*MockcookieManager)(nil).writeAuthCookie), w, sameSiteStrict, cval)
 }

--- a/oidc_test.go
+++ b/oidc_test.go
@@ -134,7 +134,7 @@ func TestApp_CallbackOIDC(t *testing.T) {
 				oidc.EXPECT().LoginURL().Return("/login").Times(1)
 				oidc.EXPECT().Verify(gomock.Any(), w, r, gomock.Any()).Return("testReturnUrl", "a test SID value", nil).Times(1)
 				s.EXPECT().NewSession(gomock.Any(), gomock.Any(), gomock.Any()).Return(ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5")), nil).Times(1)
-				c.EXPECT().newAuthCookie(w, false, ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5")), "").Return(map[scKey]string{scSessionID: "de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5"}, errors.New("failed to create new auth cookie")).Times(1)
+				c.EXPECT().newAuthCookie(w, false, ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5"))).Return(map[scKey]string{scSessionID: "de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5"}, errors.New("failed to create new auth cookie")).Times(1)
 			},
 			wantRedirectURL: fmt.Sprintf("/login?message=%s", url.QueryEscape("Internal Server Error")),
 			wantErr:         true,
@@ -145,7 +145,7 @@ func TestApp_CallbackOIDC(t *testing.T) {
 				oidc.EXPECT().LoginURL().Return("/login").Times(1)
 				oidc.EXPECT().Verify(gomock.Any(), w, r, gomock.Any()).Return("testReturnUrl", "a test SID value", nil).Times(1)
 				s.EXPECT().NewSession(gomock.Any(), gomock.Any(), gomock.Any()).Return(ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5")), nil).Times(1)
-				c.EXPECT().newAuthCookie(w, false, ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5")), "").Return(map[scKey]string{scSessionID: "de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5"}, nil).Times(1)
+				c.EXPECT().newAuthCookie(w, false, ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5"))).Return(map[scKey]string{scSessionID: "de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5"}, nil).Times(1)
 				c.EXPECT().setXSRFTokenCookie(w, r, ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5")), xsrfCookieLife).Return(true).Times(1)
 				u.EXPECT().Domains(gomock.Any()).Return(nil, errors.New("failed to get domains")).Times(1)
 			},
@@ -165,7 +165,7 @@ func TestApp_CallbackOIDC(t *testing.T) {
 						return "testReturnUrl", "a test SID value", nil
 					}).Times(1)
 				s.EXPECT().NewSession(gomock.Any(), gomock.Any(), gomock.Any()).Return(ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5")), nil).Times(1)
-				c.EXPECT().newAuthCookie(w, false, ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5")), "").Return(map[scKey]string{scSessionID: "de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5"}, nil).Times(1)
+				c.EXPECT().newAuthCookie(w, false, ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5"))).Return(map[scKey]string{scSessionID: "de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5"}, nil).Times(1)
 				c.EXPECT().setXSRFTokenCookie(w, r, ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5")), xsrfCookieLife).Return(true).Times(1)
 				u.EXPECT().Domains(gomock.Any()).Return([]accesstypes.Domain{"testDomain1", "test domain 2"}, nil).Times(1)
 				u.EXPECT().UserRoles(gomock.Any(), accesstypes.User("test username"), []accesstypes.Domain{"testDomain1", "test domain 2"}).Return(nil, errors.New("failed to get user roles")).Times(1)
@@ -186,7 +186,7 @@ func TestApp_CallbackOIDC(t *testing.T) {
 						return "testReturnUrl", "a test SID value", nil
 					}).Times(1)
 				s.EXPECT().NewSession(gomock.Any(), gomock.Any(), gomock.Any()).Return(ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5")), nil).Times(1)
-				c.EXPECT().newAuthCookie(w, false, ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5")), "").Return(map[scKey]string{scSessionID: "de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5"}, nil).Times(1)
+				c.EXPECT().newAuthCookie(w, false, ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5"))).Return(map[scKey]string{scSessionID: "de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5"}, nil).Times(1)
 				c.EXPECT().setXSRFTokenCookie(w, r, ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5")), xsrfCookieLife).Return(true).Times(1)
 				u.EXPECT().Domains(gomock.Any()).Return([]accesstypes.Domain{"testDomain1", "test domain 2"}, nil).Times(1)
 				u.EXPECT().UserRoles(gomock.Any(), accesstypes.User("test username"), []accesstypes.Domain{"testDomain1", "test domain 2"}).Return(map[accesstypes.Domain][]accesstypes.Role{
@@ -212,7 +212,7 @@ func TestApp_CallbackOIDC(t *testing.T) {
 						return "testReturnUrl", "a test SID value", nil
 					}).Times(1)
 				s.EXPECT().NewSession(gomock.Any(), gomock.Any(), gomock.Any()).Return(ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5")), nil).Times(1)
-				c.EXPECT().newAuthCookie(w, false, ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5")), "").Return(map[scKey]string{scSessionID: "de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5"}, nil).Times(1)
+				c.EXPECT().newAuthCookie(w, false, ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5"))).Return(map[scKey]string{scSessionID: "de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5"}, nil).Times(1)
 				c.EXPECT().setXSRFTokenCookie(w, r, ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5")), xsrfCookieLife).Return(true).Times(1)
 				u.EXPECT().Domains(gomock.Any()).Return([]accesstypes.Domain{"testDomain1", "test domain 2"}, nil).Times(1)
 				u.EXPECT().UserRoles(gomock.Any(), accesstypes.User("test username"), []accesstypes.Domain{"testDomain1", "test domain 2"}).Return(map[accesstypes.Domain][]accesstypes.Role{
@@ -239,7 +239,7 @@ func TestApp_CallbackOIDC(t *testing.T) {
 						return "testReturnUrl", "a test SID value", nil
 					}).Times(1)
 				s.EXPECT().NewSession(gomock.Any(), gomock.Any(), gomock.Any()).Return(ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5")), nil).Times(1)
-				c.EXPECT().newAuthCookie(w, false, ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5")), "").Return(map[scKey]string{scSessionID: "de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5"}, nil).Times(1)
+				c.EXPECT().newAuthCookie(w, false, ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5"))).Return(map[scKey]string{scSessionID: "de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5"}, nil).Times(1)
 				c.EXPECT().setXSRFTokenCookie(w, r, ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5")), xsrfCookieLife).Return(true).Times(1)
 				u.EXPECT().Domains(gomock.Any()).Return([]accesstypes.Domain{"testDomain1", "test domain 2"}, nil).Times(1)
 				u.EXPECT().UserRoles(gomock.Any(), accesstypes.User("test username"), []accesstypes.Domain{"testDomain1", "test domain 2"}).Return(map[accesstypes.Domain][]accesstypes.Role{
@@ -265,7 +265,7 @@ func TestApp_CallbackOIDC(t *testing.T) {
 						return "testReturnUrl", "a test SID value", nil
 					}).Times(1)
 				s.EXPECT().NewSession(gomock.Any(), gomock.Any(), gomock.Any()).Return(ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5")), nil).Times(1)
-				c.EXPECT().newAuthCookie(w, false, ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5")), "").Return(map[scKey]string{scSessionID: "de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5"}, nil).Times(1)
+				c.EXPECT().newAuthCookie(w, false, ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5"))).Return(map[scKey]string{scSessionID: "de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5"}, nil).Times(1)
 				c.EXPECT().setXSRFTokenCookie(w, r, ccc.Must(ccc.UUIDFromString("de6e1a12-2d4d-4c4d-aaf1-d82cb9a9eff5")), xsrfCookieLife).Return(true).Times(1)
 				u.EXPECT().Domains(gomock.Any()).Return([]accesstypes.Domain{"testDomain1", "test domain 2"}, nil).Times(1)
 				u.EXPECT().UserRoles(gomock.Any(), accesstypes.User("test username"), []accesstypes.Domain{"testDomain1", "test domain 2"}).Return(map[accesstypes.Domain][]accesstypes.Role{

--- a/preauth_test.go
+++ b/preauth_test.go
@@ -34,7 +34,7 @@ func TestPreauthSession_NewSession(t *testing.T) {
 
 				// Simulate cookie setting
 				mockCookies.EXPECT().
-					newAuthCookie(gomock.Any(), false, gomock.Any(), gomock.Any()).
+					newAuthCookie(gomock.Any(), false, gomock.Any()).
 					DoAndReturn(func(w http.ResponseWriter, _ bool, sessionID ccc.UUID, _ string) (map[scKey]string, error) {
 						http.SetCookie(w, &http.Cookie{
 							Name:  "auth",
@@ -76,7 +76,7 @@ func TestPreauthSession_NewSession(t *testing.T) {
 
 				// Simulate failure in setting the auth cookie
 				mockCookies.EXPECT().
-					newAuthCookie(gomock.Any(), false, gomock.Any(), gomock.Any()).
+					newAuthCookie(gomock.Any(), false, gomock.Any()).
 					Return(nil, errors.New("failed to set auth cookie")).
 					Times(1)
 			},

--- a/session.go
+++ b/session.go
@@ -69,7 +69,7 @@ func (s *session) StartSession(next http.Handler) http.Handler {
 			if err != nil {
 				return httpio.NewEncoder(w).ClientMessage(ctx, err)
 			}
-			cval, err = s.newAuthCookie(w, true, sessionID, s.domain)
+			cval, err = s.newAuthCookie(w, true, sessionID)
 			if err != nil {
 				return httpio.NewEncoder(w).ClientMessage(ctx, err)
 			}
@@ -78,7 +78,7 @@ func (s *session) StartSession(next http.Handler) http.Handler {
 		// Upgrade cookie to SameSite=Strict
 		// since CallbackOIDC() sets it to None to allow OAuth flow to work
 		if cval[scSameSiteStrict] != strconv.FormatBool(true) {
-			if err := s.writeAuthCookie(w, true, cval, s.domain); err != nil {
+			if err := s.writeAuthCookie(w, true, cval); err != nil {
 				return httpio.NewEncoder(w).ClientMessage(ctx, err)
 			}
 		}

--- a/session_test.go
+++ b/session_test.go
@@ -49,7 +49,7 @@ func mockRequestWithSession(ctx context.Context, t *testing.T, method string, sc
 		}
 
 		a := &session{cookieManager: &cookieClient{secureCookie: sc}}
-		if _, err := a.newAuthCookie(w, false, id, ""); err != nil {
+		if _, err := a.newAuthCookie(w, false, id); err != nil {
 			t.Fatalf("newAuthCookie() = %v", err)
 		}
 
@@ -131,7 +131,7 @@ func TestAppStartSession(t *testing.T) {
 					scSessionID:      "92922509-82d2-4ba-853a-d73b8926a55f",
 					scSameSiteStrict: "true",
 				}, true)
-				c.EXPECT().newAuthCookie(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				c.EXPECT().newAuthCookie(gomock.Any(), gomock.Any(), gomock.Any()).
 					Do(func(_ http.ResponseWriter, _ bool, sessionID ccc.UUID, _ string) {
 						tt.wantSessionID = sessionID
 					}).
@@ -147,7 +147,7 @@ func TestAppStartSession(t *testing.T) {
 			req:  mockRequestWithSession(context.Background(), t, http.MethodGet, securecookie.New(securecookie.GenerateRandomKey(32), nil), "", time.Second*5),
 			prepare: func(c *MockcookieManager, tt *test) {
 				c.EXPECT().readAuthCookie(gomock.Any()).Return(nil, false)
-				c.EXPECT().newAuthCookie(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				c.EXPECT().newAuthCookie(gomock.Any(), gomock.Any(), gomock.Any()).
 					Do(func(_ http.ResponseWriter, _ bool, sessionID ccc.UUID, _ string) {
 						tt.wantSessionID = sessionID
 					}).
@@ -167,7 +167,7 @@ func TestAppStartSession(t *testing.T) {
 				}, true)
 				c.EXPECT().writeAuthCookie(gomock.Any(), true, map[scKey]string{
 					scSessionID: "92922509-82d2-4bc7-853a-d73b8926a55f",
-				}, "").Return(nil)
+				}).Return(nil)
 			},
 			wantSessionID:  ccc.Must(ccc.UUIDFromString("92922509-82d2-4bc7-853a-d73b8926a55f")),
 			expectedStatus: http.StatusOK,
@@ -195,7 +195,7 @@ func TestAppStartSession(t *testing.T) {
 				c.EXPECT().writeAuthCookie(gomock.Any(), true, map[scKey]string{
 					scSessionID:      "92922509-82d2-4bc7-853a-d73b8926a55f",
 					scSameSiteStrict: "false",
-				}, "").Return(errors.New("error writing cookie"))
+				}).Return(errors.New("error writing cookie"))
 			},
 			expectedStatus: http.StatusInternalServerError,
 		},
@@ -204,7 +204,7 @@ func TestAppStartSession(t *testing.T) {
 			req:  &http.Request{URL: &url.URL{}},
 			prepare: func(c *MockcookieManager, _ *test) {
 				c.EXPECT().readAuthCookie(gomock.Any()).Return(nil, false)
-				c.EXPECT().newAuthCookie(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("error creating cookie"))
+				c.EXPECT().newAuthCookie(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("error creating cookie"))
 			},
 			expectedStatus: http.StatusInternalServerError,
 		},


### PR DESCRIPTION
Adds in the functional pattern of Options for NewPreAuth and NewOIDCAzure