### PR TITLE
fix: Add SameSite Strict to XSRF cookie

### DIFF
--- a/cookies.go
+++ b/cookies.go
@@ -185,11 +185,12 @@ func (c *cookieClient) writeXSRFCookie(w http.ResponseWriter, cookieExpiration t
 	}
 
 	http.SetCookie(w, &http.Cookie{
-		Name:    stCookieName,
-		Expires: time.Now().Add(cookieExpiration),
-		Value:   encoded,
-		Path:    "/",
-		Secure:  secureCookie(),
+		Name:     stCookieName,
+		Expires:  time.Now().Add(cookieExpiration),
+		Value:    encoded,
+		Path:     "/",
+		Secure:   secureCookie(),
+		SameSite: http.SameSiteStrictMode,
 	})
 
 	return nil


### PR DESCRIPTION
Adds the SameSite strict flag to the XSRF cookie that we generate when using this package

